### PR TITLE
Allow Defaulted Loan Repayments and Fix New Account Creation

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 
 game 'rdr3'
 lua54 'yes'
-version '1.3.0'
+version '1.3.1'
 author 'BCC Scripts'
 
 client_scripts {

--- a/server/controllers/accounts.lua
+++ b/server/controllers/accounts.lua
@@ -12,10 +12,11 @@ end
 
 function GetAccountCount(owner, bank)
     local result = MySQL.query.await(
-        'SELECT COUNT(*) FROM `bcc_accounts` WHERE `owner_id` = ? AND `bank_id` = ?',
+        'SELECT COUNT(*) AS cnt FROM `bcc_accounts` WHERE `owner_id` = ? AND `bank_id` = ?',
         { owner, bank }
     )
-    return result and result[1] and result[1]["COUNT(*)"] or 0
+    local row = result and result[1]
+    return tonumber(row and (row.cnt or row["COUNT(*)"])) or 0
 end
 
 function CreateAccount(name, owner, bank)

--- a/server/controllers/loans.lua
+++ b/server/controllers/loans.lua
@@ -106,7 +106,11 @@ function RepayLoan(loan_id, account_id, character_id, amount)
     -- Mark loan paid if fully repaid
     local after = ComputeLoanOutstanding(loan_id)
     if after and (after.outstanding or 0) <= 0 then
-        MySQL.query.await('UPDATE `bcc_loans` SET `status` = "paid" WHERE `id` = ?', { loan_id })
+        MySQL.query.await('UPDATE `bcc_loans` SET `status` = "paid", `is_defaulted` = 0 WHERE `id` = ?', { loan_id })
+        local ownerChar = (after.loan and after.loan.character_id) or (info and info.loan and info.loan.character_id) or character_id
+        if ownerChar then
+            SetOwnerAccountsFrozen(tonumber(ownerChar), false)
+        end
     end
 
     return { status = true }

--- a/version
+++ b/version
@@ -1,4 +1,8 @@
-**v1.3.0 — Changelog**
+<1.3.1>
+- Let defaulted loans be repaid and automatically thaw the borrower’s accounts once the balance reaches zero.
+- Reset is_defaulted alongside the status so cleared loans look like normal paid loans in the DB.
+- Fix GetAccountCount to coerce the SQL result into a number, resolving the “Unable to create account” error on fresh installs.
+<1.3.0>
 - Added: mailbox notification on loan approve/reject via `bcc-maibox`
 - Added: configurable `loanbStatusMail`
 - Added: admins/bankers can access SDBs


### PR DESCRIPTION
- Let defaulted loans be repaid and automatically thaw the borrower’s accounts once the balance reaches zero.
- Reset is_defaulted alongside the status so cleared loans look like normal paid loans in the DB.
- Fix GetAccountCount to coerce the SQL result into a number, resolving the “Unable to create account” error on fresh installs.